### PR TITLE
Add chest value notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,6 @@ Alternatively you can check the "Show exact value" setting if you want to see th
 ### Chest Value Notifications
 In the plugin settings you can enable the "Chest value notification" setting to receive notifications when the chest value exceeds a certain threshold.
 
+To receive notifications you will need to have the chest interface open.
+
 By default, the threshold is set to 100k, and it can be adjusted using the "Chest value threshold" setting.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,14 @@ RuneLite plugin to show the total GE value of items in the party room and clan h
 ## Installation
 Search "Drop Party Chest" in the external plugins section in the configuration menu.
 
-Click the install button.
+Click the install-button.
 
 ## Usage
-By default this plugin will show total chest value shortened with K and M when the chest interface is open.
+By default, this plugin will show total chest value shortened with K and M when the chest interface is open.
 
 Alternatively you can check the "Show exact value" setting if you want to see the full amount.
+
+### Chest Value Notifications
+In the plugin settings you can enable the "Chest value notification" setting to receive notifications when the chest value exceeds a certain threshold.
+
+By default, the threshold is set to 100k, and it can be adjusted using the "Chest value threshold" setting.

--- a/src/main/java/io/grnbk/droppartychest/DropPartyChestConfig.java
+++ b/src/main/java/io/grnbk/droppartychest/DropPartyChestConfig.java
@@ -3,6 +3,7 @@ package io.grnbk.droppartychest;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Notification;
 
 @ConfigGroup("drop-party-chest")
 public interface DropPartyChestConfig extends Config
@@ -10,10 +11,33 @@ public interface DropPartyChestConfig extends Config
 	@ConfigItem(
 		keyName = "showExact",
 		name = "Show exact chest value",
-		description = "Show exact chest value."
+		description = "Show exact chest value.",
+        position = 0
 	)
 	default boolean showExact()
 	{
 		return false;
 	}
+
+    @ConfigItem(
+            keyName = "chestValueNotification",
+            name = "Chest value notification",
+            description = "Configures if chest value notifications are enabled.",
+            position = 1
+    )
+    default Notification getChestValueNotification()
+    {
+        return Notification.OFF;
+    }
+
+    @ConfigItem(
+            keyName = "chestValueThreshold",
+            name = "Chest value threshold",
+            description = "The total value of the chest must exceed this amount to send a notification.",
+            position = 2
+    )
+    default int getChestValueThreshold()
+    {
+        return 100000;
+    }
 }

--- a/src/main/java/io/grnbk/droppartychest/DropPartyChestConfig.java
+++ b/src/main/java/io/grnbk/droppartychest/DropPartyChestConfig.java
@@ -20,10 +20,10 @@ public interface DropPartyChestConfig extends Config
 	}
 
     @ConfigItem(
-            keyName = "chestValueNotification",
-            name = "Chest value notification",
-            description = "Configures if chest value notifications are enabled.",
-            position = 1
+        keyName = "chestValueNotification",
+        name = "Chest value notification",
+        description = "Configures if chest value notifications are enabled.",
+        position = 1
     )
     default Notification getChestValueNotification()
     {
@@ -31,10 +31,10 @@ public interface DropPartyChestConfig extends Config
     }
 
     @ConfigItem(
-            keyName = "chestValueThreshold",
-            name = "Chest value threshold",
-            description = "The total value of the chest must exceed this amount to send a notification.",
-            position = 2
+        keyName = "chestValueThreshold",
+        name = "Chest value threshold",
+        description = "The total value of the chest must exceed this amount to send a notification.",
+        position = 2
     )
     default int getChestValueThreshold()
     {

--- a/src/main/java/io/grnbk/droppartychest/DropPartyChestPlugin.java
+++ b/src/main/java/io/grnbk/droppartychest/DropPartyChestPlugin.java
@@ -8,9 +8,11 @@ import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.widgets.Widget;
+import net.runelite.client.Notifier;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -40,8 +42,35 @@ public class DropPartyChestPlugin extends Plugin
 	@Inject
 	private ItemManager itemManager;
 
+    @Inject
+    private Notifier notifier;
+
 	@Inject
 	private DropPartyChestConfig config;
+
+    private boolean notifyChestValue = false;
+    private long currentThreshold;
+
+    @Override
+    protected void startUp() throws Exception
+    {
+        currentThreshold = config.getChestValueThreshold();
+    }
+
+    @Subscribe
+    public void onConfigChanged(ConfigChanged event)
+    {
+        if (!event.getGroup().equals("drop-party-chest"))
+        {
+            return;
+        }
+
+        if (event.getKey().equals("chestValueThreshold"))
+        {
+            currentThreshold = config.getChestValueThreshold();
+            notifyChestValue = false;
+        }
+    }
 
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
@@ -76,6 +105,15 @@ public class DropPartyChestPlugin extends Plugin
 		if (itemContainer != null)
 		{
 			final long totalChestItemsValue = getTotalGrandExchangeValue(itemContainer.getItems());
+
+            if (checkChestValueExceeded(totalChestItemsValue))
+            {
+                String thresholdValue = QuantityFormatter.quantityToStackSize(currentThreshold);
+                String message = "Party chest value exceeds " + thresholdValue + "!";
+
+                notifier.notify(config.getChestValueNotification(), message);
+            }
+
 			if (totalChestItemsValue > 0)
 			{
 				final String totalChestValueText = createValueText(totalChestItemsValue);
@@ -87,6 +125,27 @@ public class DropPartyChestPlugin extends Plugin
 			}
 		}
 	}
+
+    private boolean checkChestValueExceeded(final long totalChestItemsValue)
+    {
+        if (currentThreshold == 0)
+        {
+            return false;
+        }
+        if (currentThreshold <= totalChestItemsValue)
+        {
+            if (!notifyChestValue)
+            {
+                notifyChestValue = true;
+                return true;
+            }
+        }
+        else
+        {
+            notifyChestValue = false;
+        }
+        return false;
+    }
 
 	private long getTotalGrandExchangeValue(Item[] items)
 	{

--- a/src/main/java/io/grnbk/droppartychest/DropPartyChestPlugin.java
+++ b/src/main/java/io/grnbk/droppartychest/DropPartyChestPlugin.java
@@ -109,7 +109,7 @@ public class DropPartyChestPlugin extends Plugin
             if (checkChestValueExceeded(totalChestItemsValue))
             {
                 String thresholdValue = QuantityFormatter.quantityToStackSize(currentThreshold);
-                String message = "Party chest value exceeds " + thresholdValue + "!";
+                String message = "Party chest value exceeds " + thresholdValue + " gp!";
 
                 notifier.notify(config.getChestValueNotification(), message);
             }


### PR DESCRIPTION
This PR adds notifications for when chest value exceeds a configurable threshold. The chest interface must be open to receive these notifications. The notifications themselves can be customized like in other plugins.

This functionality was requested in issue #1.